### PR TITLE
remove deployment on PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Any automatic deployment should be done on "push" to master and not "pull request". This simple deletion fixes that. 

Although, in the future, we may still include checks for every PR to make sure that the "yarn build" command can run with no warnings or errors.